### PR TITLE
s390x: remove the volume

### DIFF
--- a/s390x.Dockerfile
+++ b/s390x.Dockerfile
@@ -50,8 +50,6 @@ WORKDIR ${homedir}
 RUN curl -L https://github.com/actions/runner/releases/download/v${version}/actions-runner-linux-x64-${version}.tar.gz | tar -xz
 USER root
 
-VOLUME ${homedir}
-
 # WARNING: This needs to be set at the end of the file or it will have side effects when building the container
 # from within a foreign arch (like building on x86 host).
 # amd64 dependencies.


### PR DESCRIPTION
When the runner tries to auto-update, it may enter and endless loop when a volume stanza is set to workdir.

Based on https://docs.docker.com/engine/reference/builder/#volume

> The docker run command initializes the newly created volume with any data that exists at the specified location within the base image.

So, when we have a container with version X, the runner may start, see it needs version X+1, upgrade and restarts.
In ephemeral mode, this results in a containers restart, remounting the volumes with a copy of the content in the image, e.g version X, which needs update.....