### PR TITLE
[workflow] Add workflow to automatically bump the s390x runner version

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -1,0 +1,39 @@
+name: s390x version bump
+
+# This workflow pulls the latest official actions runner version using GH API
+# and update our s390x Dockerfile.
+# If a change happens, the chnage will be commited.
+# The workflow can be triggered manually (workflow_dispatch) but also runs nightly
+# before the nightly rebuild.
+on:
+  schedule:
+    - cron: '00 17 * * *'
+  workflow_dispatch:
+
+jobs:
+  bump_version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Get latest runner release
+        id: release
+        run: |
+          ACTIONS_VERSION=$(curl -L https://api.github.com/repos/actions/runner/releases/latest | jq -r '.name[1:]')
+          if [ "${ACTIONS_VERSION}" == "null" ]
+          then
+            echo "::error Invalid ACTIONS_VERSION ${ACTIONS_VERSION}"
+            exit 1
+          fi
+          echo "ACTIONS_VERSION=${ACTIONS_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Update release
+        id: bump
+        run: sed -i 's#^ARG version=.*#ARG version=${{ steps.release.outputs.ACTIONS_VERSION}}#' s390x.Dockerfile
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "[automated] Bumping s390x containers to action-runners v${{ steps.release.outputs.ACTIONS_VERSION}}"


### PR DESCRIPTION
Get the last release from GH API and update the relevant line in the Dockerfile